### PR TITLE
feat: replace gfind with gmatch

### DIFF
--- a/src/radix.lua
+++ b/src/radix.lua
@@ -85,7 +85,7 @@ local new = function()
   -- adds a new element to the tree
   local add_to_tree = function(word)
     local t = j.radix_tree
-    for char in word:gfind('.') do
+    for char in word:gmatch('.') do
       if t[char] == true or t[char] == nil then
         t[char] = {}
       end
@@ -98,7 +98,7 @@ local new = function()
   -- removes an element from the tree
   local remove_from_tree = function(word)
     local t = j.radix_tree
-    for char in word:gfind('.') do
+    for char in word:gmatch('.') do
       if t[char] == true then
         return
       end


### PR DESCRIPTION
The `gfind` method was deprecated on `Lua 5.1` and is not available in `Lua 5.2 (or later versions)` and `Luajit` (which is the one I'm using fo the project I intended to use lua-radixtree).
So, my suggestion here is to replace the usages of `gfind` with `gmatch`.